### PR TITLE
Update side_event_arranger.dart

### DIFF
--- a/lib/src/event_arrangers/side_event_arranger.dart
+++ b/lib/src/event_arrangers/side_event_arranger.dart
@@ -81,8 +81,8 @@ class SideEventArranger<T> extends EventArranger<T> {
               events: [event],
               left: left,
               right: right,
-              endDuration: event.startTime ?? DateTime.now(),
-              startDuration: event.endTime ?? DateTime.now(),
+              startDuration: event.startTime ?? DateTime.now(),
+              endDuration: event.endTime ?? DateTime.now(),
             );
             arrangedEvent.add(eventData);
           } else {


### PR DESCRIPTION
fixed issue where values of `startDuration` and `endDuration` fields in `eventTileBuilder` callback of` DayView` are interchanged